### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,4 +1,6 @@
 name: SonarCloud
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/amoraschi/amoraschi.github.io/security/code-scanning/1](https://github.com/amoraschi/amoraschi.github.io/security/code-scanning/1)

The best way to fix this problem is to explicitly restrict the reusable workflow or the particular job's permissions by adding a `permissions:` block. Since the SonarQube scan only reads repository content and does not modify code or interact with PRs/issues, the minimal permission `contents: read` suffices. This should ideally be set at the workflow root, so it applies to all jobs. Edit `.github/workflows/sonar.yml` and add:

```yaml
permissions:
  contents: read
```

between the `name: SonarCloud` and `on:` lines. This will ensure all jobs within the workflow inherit this least-privilege permissions setup, unless overridden at the job level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
